### PR TITLE
fix: set different size for Heading 4

### DIFF
--- a/src/components/RichText/RichTextEditor.tsx
+++ b/src/components/RichText/RichTextEditor.tsx
@@ -42,6 +42,7 @@ function RTE({ value, onChange, placeholder }: RichTextEditorProps) {
       { label: t("rte.h1"), style: "header-one" },
       { label: t("rte.h2"), style: "header-two" },
       { label: t("rte.h3"), style: "header-three" },
+      { label: t("rte.h4"), style: "header-four" },
       { label: t("rte.h5"), style: "header-five" },
     ],
     BLOCK_TYPE_BUTTONS: [

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -124,6 +124,7 @@
   "rte.h1": "Headline 1. Ordnung",
   "rte.h2": "Headline 2. Ordnung",
   "rte.h3": "Headline 3. Ordnung",
+  "rte.h4": "Headline 4. Ordnung",
   "rte.h5": "Headline 5. Ordnung",
   "rte.text": "Text"
 }


### PR DESCRIPTION
small change to h5 size for heading 4 (so it differentiates from the normal text size)