### PR TITLE
fix: image option removed for now

### DIFF
--- a/src/components/RichText/RichTextEditor.tsx
+++ b/src/components/RichText/RichTextEditor.tsx
@@ -30,7 +30,6 @@ function RTE({ value, onChange, placeholder }: RichTextEditorProps) {
       "INLINE_STYLE_BUTTONS",
       "BLOCK_TYPE_BUTTONS",
       "LINK_BUTTONS",
-      "IMAGE_BUTTON",
     ],
     INLINE_STYLE_BUTTONS: [
       { label: "Bold", style: "BOLD", className: "custom-css-class" },


### PR DESCRIPTION
As react-rte does not support image, we should look further into implementing a different rich text editor in the near future. For now I removed the image link option on the RTE so it does not mislead the user.