### PR TITLE
fix: edit/delete buttons right fixed & visible for counselors & agencies

### DIFF
--- a/src/components/Agency/AgencyList.tsx
+++ b/src/components/Agency/AgencyList.tsx
@@ -56,6 +56,7 @@ function AgencyList() {
         width: 150,
         ellipsis: true,
         className: "agencyList__column",
+        fixed: "left",
       },
       {
         title: t("agency.description"),
@@ -122,7 +123,7 @@ function AgencyList() {
         className: "agencyList__column",
       },
       {
-        width: 80,
+        width: 60,
         title: t("status"),
         dataIndex: "status",
         key: "status",
@@ -133,7 +134,7 @@ function AgencyList() {
         className: "agencyList__column",
       },
       {
-        width: 88,
+        width: 80,
         title: "",
         key: "edit",
         render: (_: any, record: AgencyData) => {
@@ -155,6 +156,7 @@ function AgencyList() {
           );
         },
         className: "agencyList__column",
+        fixed: "right",
       },
     ];
   }

--- a/src/components/Counselor/CounselorList.tsx
+++ b/src/components/Counselor/CounselorList.tsx
@@ -217,7 +217,7 @@ function CounselorList() {
       title: "",
       dataIndex: "openStatus",
       key: "openStatus",
-      width: 50,
+      width: 30,
       fixed: "left",
       render: (_: any, record: ModifiedCounselorData) => {
         if (record.openStatus === OpenStatus.NOT_AVAILABLE) return null;
@@ -312,7 +312,7 @@ function CounselorList() {
       className: "counselorList__column",
     },
     {
-      width: 80,
+      width: 60,
       title: t("status"),
       dataIndex: "status",
       key: "status",
@@ -323,7 +323,7 @@ function CounselorList() {
       className: "counselorList__column",
     },
     {
-      width: 88,
+      width: 80,
       title: "",
       key: "edit",
       render: (_: any, record: CounselorData) => {
@@ -339,6 +339,7 @@ function CounselorList() {
         );
       },
       className: "counselorList__column",
+      fixed: "right",
     },
   ];
 


### PR DESCRIPTION
really minor changes about the edit/delete buttons being fixed on the admin so the user can see them always in the Berater and Beratungstelle tabs.