### PR TITLE
feat: hide languages in for some users

### DIFF
--- a/src/constants/userRolesToPermissions.ts
+++ b/src/constants/userRolesToPermissions.ts
@@ -31,6 +31,7 @@ export const useUserRolesToPermission = () => {
         },
         [UserRole.TenantAdmin]: {
             Tenant: { read: true, update: true },
+            Language: { update: true },
             LegalText: { read: true, update: true },
             Statistic: { read: true },
         },
@@ -39,6 +40,7 @@ export const useUserRolesToPermission = () => {
         },
         [UserRole.SingleTenantAdmin]: {
             Tenant: { read: true, update: true },
+            Language: { update: !settings.multitenancyWithSingleDomainEnabled },
             LegalText: {
                 read: singleCanEditLegalText,
                 update: singleCanEditLegalText,

--- a/src/enums/Resource.ts
+++ b/src/enums/Resource.ts
@@ -6,4 +6,5 @@ export enum Resource {
     Statistic,
     Tenant,
     LegalText,
+    Language,
 }

--- a/src/pages/TenantSettings/GeneralSettings/index.tsx
+++ b/src/pages/TenantSettings/GeneralSettings/index.tsx
@@ -1,15 +1,20 @@
 import { Col, Row } from 'antd';
+import { PermissionAction } from '../../../enums/PermissionAction';
+import { Resource } from '../../../enums/Resource';
+import { useUserPermissions } from '../../../hooks/useUserPermission';
 import { Languages } from './components/Languages';
 import { LogoAndFavicon } from './components/LogoAndFavicon';
 import { NameAndSlogan } from './components/NameAndSlogan';
 import { TenantColor } from './components/TenantColor';
 
 export const GeneralSettings = () => {
+    const { can } = useUserPermissions();
+
     return (
         <Row gutter={[24, 24]}>
             <Col span={12} sm={6}>
                 <NameAndSlogan />
-                <Languages />
+                {can(PermissionAction.Update, Resource.Language) && <Languages />}
             </Col>
             <Col span={12} sm={6}>
                 <LogoAndFavicon />


### PR DESCRIPTION
When we've the multi tenancy with single domain enabled but the user is single tenant admin we should hide the languages selection